### PR TITLE
Fix notification settings being stuck in AM time after save

### DIFF
--- a/screens/Settings/Notifications.js
+++ b/screens/Settings/Notifications.js
@@ -25,9 +25,16 @@ const NotificationsSettings = () => {
                 if (value) {
                     const date = new Date();
                     const splitValue = value.split(':')
+                    
+                    const AM = value.slice(-2) === “AM”
+                    let hours = parseInt(splitValue[1])
+                    if (AM) hours += 12
 
-                    date.setHours(parseInt(splitValue[0]))
+                    date.setHours(hours)
                     date.setMinutes(parseInt(splitValue[1]))
+                    
+                    const AM = splitValue[1].slice(-2) === “AM”
+                    if (AM) 
 
                     setDate(date)
                     setNotificationTimeString(value)


### PR DESCRIPTION
When you would go into the Notification Settings and set the notification time to PM, if you would go out of the Notification Settings and back into them again then the notification time would be set to AM instead of PM. This commit fixes that issue.